### PR TITLE
expose visibleItems via onScrolled attribute

### DIFF
--- a/addon/components/paper-virtual-repeat.js
+++ b/addon/components/paper-virtual-repeat.js
@@ -24,6 +24,7 @@ const VirtualRepeatComponent = VirtualEachComponent.extend({
   actions: {
     onScroll(e) {
       this.eventHandlers.scroll.call(this, e);
+      this.sendAction('onScrolled', this.get('visibleItems'));
     }
   },
 


### PR DESCRIPTION
This adds a way to expose the current visible items when scrolling. If there is a better way to do this please let me know!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miguelcobain/ember-paper/573)
<!-- Reviewable:end -->
