### PR TITLE
feat(dialog): Expose onClose as yielded action so user doesn't have t…

### DIFF
--- a/addon/templates/components/paper-dialog.hbs
+++ b/addon/templates/components/paper-dialog.hbs
@@ -14,7 +14,7 @@
       defaultedCloseTo=defaultedCloseTo
       fullscreen=fullscreen
       focusOnOpen=focusOnOpen}}
-      {{yield}}
+      {{yield onClose}}
     {{/paper-dialog-inner}}
   {{/paper-dialog-container}}
 {{/ember-wormhole}}


### PR DESCRIPTION
…o duplicate in footer.

Basically, allows this:

```hbs
{{#if myDialog}}
  {{#paper-dialog fullscreen=true onClose=(action (mut myDialog) false) as |close|}}
    {{#paper-dialog-content}}
      <h2 class="md-title">Register or Sign In</h2>
      <p>...</p>
    {{/paper-dialog-content}}

    {{#paper-dialog-actions class="layout-row"}}
      <span class="flex"></span>
      {{#paper-button primary=true onClick=close}}I'm a cat person{{/paper-button}}
      {{#paper-button primary=true onClick=(action 'submit' close)}}Okay!{{/paper-button}}
    {{/paper-dialog-actions}}
  {{/paper-dialog}}
{{/if}}
```