### PR TITLE
refactor: migrates to `htmlSafe` from `@ember/template`.

### DIFF
--- a/addon/components/paper-icon.js
+++ b/addon/components/paper-icon.js
@@ -6,7 +6,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 

--- a/addon/components/paper-ink-bar.js
+++ b/addon/components/paper-ink-bar.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-classic-components, ember/require-tagless-components, prettier/prettier */
 import { computed } from '@ember/object';
 import Component from '@ember/component';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 export default Component.extend({
   tagName: 'md-ink-bar',

--- a/addon/components/paper-progress-circular.js
+++ b/addon/components/paper-progress-circular.js
@@ -8,7 +8,7 @@ import { equal } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isPresent } from '@ember/utils';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 import clamp from 'ember-paper/utils/clamp';
 

--- a/addon/components/paper-progress-linear.js
+++ b/addon/components/paper-progress-linear.js
@@ -7,7 +7,7 @@ import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import { isPresent } from '@ember/utils';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 
 function makeTransform(value) {

--- a/addon/components/paper-sidenav-container.js
+++ b/addon/components/paper-sidenav-container.js
@@ -4,7 +4,7 @@
  */
 import Component from '@ember/component';
 
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 /**
  * @class PaperSidenavContainer

--- a/addon/components/paper-slider/component.js
+++ b/addon/components/paper-slider/component.js
@@ -5,7 +5,7 @@
 import Component from '@ember/component';
 import { computed, action } from '@ember/object';
 import { bind } from '@ember/runloop';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import template from './template';
 import clamp from 'ember-paper/utils/clamp';
 import { tagName, layout } from '@ember-decorators/component';

--- a/addon/components/paper-speed-dial-actions-action.js
+++ b/addon/components/paper-speed-dial-actions-action.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-classic-components, ember/no-component-lifecycle-hooks, ember/no-get, ember/require-tagless-components, prettier/prettier */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 function getElementIndex(node) {
   let index = 0;

--- a/addon/components/paper-switch.js
+++ b/addon/components/paper-switch.js
@@ -8,7 +8,7 @@ import Component from '@ember/component';
 import { assert } from '@ember/debug';
 import { get, computed } from '@ember/object';
 import { bind } from '@ember/runloop';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import FocusableMixin from 'ember-paper/mixins/focusable-mixin';
 import ColorMixin from 'ember-paper/mixins/color-mixin';
 import ProxiableMixin from 'ember-paper/mixins/proxiable-mixin';

--- a/addon/components/paper-tab.js
+++ b/addon/components/paper-tab.js
@@ -8,7 +8,7 @@ import {
 
 import { computed } from '@ember/object';
 import Component from '@ember/component';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { ChildMixin } from 'ember-composability-tools';
 import FocusableMixin from 'ember-paper/mixins/focusable-mixin';
 import { invokeAction } from 'ember-paper/utils/invoke-action';

--- a/addon/components/paper-tabs.js
+++ b/addon/components/paper-tabs.js
@@ -8,7 +8,7 @@ import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { gt } from '@ember/object/computed';
 import Component from '@ember/component';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { scheduleOnce, join } from '@ember/runloop';
 import { ParentMixin } from 'ember-composability-tools';
 import ColorMixin from 'ember-paper/mixins/color-mixin';

--- a/addon/components/paper-tooltip.js
+++ b/addon/components/paper-tooltip.js
@@ -3,7 +3,7 @@ import { or } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { later } from '@ember/runloop';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { getOwner } from '@ember/application';
 import getParent from 'ember-paper/utils/get-parent';
 import { supportsPassiveEventListeners } from 'ember-paper/utils/browser-features';

--- a/addon/mixins/translate3d-mixin.js
+++ b/addon/mixins/translate3d-mixin.js
@@ -3,7 +3,7 @@
  * @module ember-paper
  */
 import Mixin from '@ember/object/mixin';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { computed } from '@ember/object';
 import { schedule, later } from '@ember/runloop';
 import { nextTick, computeTimeout } from 'ember-css-transitions/utils/transition-utils';

--- a/tests/dummy/app/components/paper-api.js
+++ b/tests/dummy/app/components/paper-api.js
@@ -2,7 +2,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { typeOf } from '@ember/utils';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 const escape = function(text) {
   // Convert backtick markup to <code> element.

--- a/tests/dummy/app/controllers/demo/slider.js
+++ b/tests/dummy/app/controllers/demo/slider.js
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-get, prettier/prettier */
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 let color = {
   red: Math.floor(Math.random() * 255),


### PR DESCRIPTION
`htmlSafe` was removed in ember@3 from `@ember/string`

These use 'stacked PRs', for better clarity see PR dependency tree from graphite here: https://github.com/linc-technologies/ember-paper/pull/14#issuecomment-2418196586