### PR TITLE
allow full-screen snapshots

### DIFF
--- a/addon/components/paper-backdrop.hbs
+++ b/addon/components/paper-backdrop.hbs
@@ -1,5 +1,6 @@
 {{! template-lint-disable no-invalid-interactive }}
 <md-backdrop
+  {{lock-body}}
   {{on "click" (fn this.sendClickAction @onClick)}}
   {{on "touchEnd" (fn this.sendClickAction @onClick)}}
   {{css-transition
@@ -14,3 +15,11 @@
   ...attributes>
   {{yield}}
 </md-backdrop>
+
+{{!-- TODO once we move to a v2 addon we should be able to import a style properly here. I added this to prevent us needing to mess with complicated style build systems --}}
+{{!-- template-lint-disable no-forbidden-elements --}}
+<style>
+  .ember-paper-lockbody {
+    overflow: hidden;
+  }
+</style>

--- a/addon/components/paper-sidenav-container.js
+++ b/addon/components/paper-sidenav-container.js
@@ -1,10 +1,8 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components, prettier/prettier */
+/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 /**
  * @module ember-paper
  */
 import Component from '@ember/component';
-
-import { htmlSafe } from '@ember/template';
 
 /**
  * @class PaperSidenavContainer
@@ -13,5 +11,4 @@ import { htmlSafe } from '@ember/template';
 export default Component.extend({
   classNames: ['flex', 'layout-row'],
   attributeBindings: ['style'],
-  style: htmlSafe('overflow: hidden')
 });

--- a/addon/modifiers/lock-body.js
+++ b/addon/modifiers/lock-body.js
@@ -1,0 +1,16 @@
+import { modifier } from 'ember-modifier';
+
+const LOCK_BODY_CLASS = 'ember-paper-lockbody';
+
+export default modifier(
+  function lockBody(/*element /*, positional, named*/) {
+    document.querySelector('body').classList.add(LOCK_BODY_CLASS);
+
+    return () => {
+      document.querySelector('body').classList.remove(LOCK_BODY_CLASS);
+    };
+  },
+  {
+    eager: false,
+  }
+);

--- a/app/modifiers/lock-body.js
+++ b/app/modifiers/lock-body.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-paper/modifiers/lock-body';

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -10,29 +10,9 @@ $accent: 'pink';
  * Needed styles to set correct widths.
  */
 
-body {
-  max-width: 100%;
-  max-height: 100%;
-}
-
-body.ember-application {
-  flex-direction: row;
-  flex: 1;
-  display: flex;
-}
-
-body > div.ember-view {
-  flex-direction: row;
-  flex: 1;
-  display: flex;
-}
-
-.site-nav-container {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+md-sidenav.md-locked-open {
+  position: sticky !important;
+  height: 100vh;
 }
 
 md-toolbar.md-warn {


### PR DESCRIPTION
The original reason for this change is because I wanted to add percy in #1296 but this is also required if you want the chrome "full screenshot" functionality to work. You can compare the preview build of this PR with the main demo app by doing the following

- open the preview app in chrome
- open dev tools
- run cmd-shift-p to open the command pallet
- type "screenshot" and select "Capture full size screenshot"

On main you'll see that scroll will be cut off and you can never get a full screenshot. This PR fixes that but needs to add some hacks to make the dialog inert. Personally I think it's a good tradeoff 👍 